### PR TITLE
Hide splitter when web panel is not visible

### DIFF
--- a/src/second_sidebar/css/sidebar_box.mjs
+++ b/src/second_sidebar/css/sidebar_box.mjs
@@ -12,6 +12,13 @@ export const SIDEBAR_BOX_CSS = `
     }
   }
 
+  #browser:has(#sb2-box[hidden="true"]) {
+    #sb2-splitter-unpinned,
+    #sb2-splitter-pinned {
+      display: none !important;
+    }
+  }
+
   #browser:has(#sb2[type="split"]) {
     #sb2-box-filler {
       display: none;


### PR DESCRIPTION
Splitter is visible even when web panel is not open, especially annoying when viewing full screen content.