### PR TITLE
Hide default sidebar splitter in web panels

### DIFF
--- a/src/second_sidebar/xul/web_panels_browser.mjs
+++ b/src/second_sidebar/xul/web_panels_browser.mjs
@@ -113,6 +113,9 @@ export class WebPanelsBrowser extends Browser {
       #zen-main-app-wrapper {
         background: transparent !important;
       }
+      #zen-sidebar-splitter {
+        display: none !important;
+      }
     `);
     windowRoot.appendChild(style);
 


### PR DESCRIPTION
Fix for recent browser update