### PR TITLE
Auto-grab tab's styles for panel buttons

### DIFF
--- a/src/second_sidebar/css/sidebar_main.mjs
+++ b/src/second_sidebar/css/sidebar_main.mjs
@@ -4,6 +4,8 @@ const sidebarLeft = /* css */ `[zen-right-side="true"]`;
 const sidebarRight = /* css */ `:not([zen-right-side="true"])`;
 const singleToolbar = /* css */ `[zen-single-toolbar="true"]`;
 
+const tabsStyle = window.getComputedStyle(document.querySelector('#tabbrowser-tabs'));
+
 export const SIDEBAR_MAIN_CSS = /* css */ `
   #sb2-main {
     display: flex;
@@ -14,6 +16,8 @@ export const SIDEBAR_MAIN_CSS = /* css */ `
     scrollbar-width: none;
     min-width: unset !important;
     padding: 0;
+    --tab-selected-bgcolor: ${tabsStyle.getPropertyValue('--tab-selected-bgcolor')};
+    --tab-selected-shadow: ${tabsStyle.getPropertyValue('--tab-selected-shadow')};
 
     toolbarpaletteitem[place="panel"][id^="wrapper-customizableui-special-spring"], toolbarspring {
       flex: 1;


### PR DESCRIPTION
Zen changed scope of tab's custom properties, so no CSS magic anymore. Have to grab values on startup with JS.